### PR TITLE
Add ability to upload blobs

### DIFF
--- a/azure/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
@@ -31,10 +31,10 @@ import fs2.Stream
 object AzureGetService {
 
   def apply[F[_]: ConcurrentEffect: ContextShift](
-      containerURL: ContainerURL,
-      mkArgs: BlobURL => DownloadArgs,
-      reliableDownloadOptions: ReliableDownloadOptions,
-      maxQueueSize: MaxQueueSize)
+    containerURL: ContainerURL,
+    mkArgs: BlobURL => DownloadArgs,
+    reliableDownloadOptions: ReliableDownloadOptions,
+    maxQueueSize: MaxQueueSize)
       : GetService[F] =
     converters.blobPathToBlobURLK(containerURL) andThen
       Kleisli[F, BlobURL, DownloadArgs](mkArgs(_).pure[F]) andThen
@@ -42,7 +42,8 @@ object AzureGetService {
       handlers.toByteStreamK(reliableDownloadOptions, maxQueueSize) mapF
       handlers.recoverNotFound[F, Stream[F, Byte]]
 
-  def mk[F[_]: ConcurrentEffect: ContextShift](containerURL: ContainerURL, maxQueueSize: MaxQueueSize): GetService[F] =
+  def mk[F[_]: ConcurrentEffect: ContextShift](containerURL: ContainerURL, maxQueueSize: MaxQueueSize)
+      : GetService[F] =
     AzureGetService(
       containerURL,
       DownloadArgs(_, BlobRange.DEFAULT, BlobAccessConditions.NONE, false, Context.NONE),

--- a/azure/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
@@ -31,10 +31,10 @@ import fs2.Stream
 object AzureGetService {
 
   def apply[F[_]: ConcurrentEffect: ContextShift](
-    containerURL: ContainerURL,
-    mkArgs: BlobURL => DownloadArgs,
-    reliableDownloadOptions: ReliableDownloadOptions,
-    maxQueueSize: MaxQueueSize)
+      containerURL: ContainerURL,
+      mkArgs: BlobURL => DownloadArgs,
+      reliableDownloadOptions: ReliableDownloadOptions,
+      maxQueueSize: MaxQueueSize)
       : GetService[F] =
     converters.blobPathToBlobURLK(containerURL) andThen
       Kleisli[F, BlobURL, DownloadArgs](mkArgs(_).pure[F]) andThen
@@ -42,8 +42,7 @@ object AzureGetService {
       handlers.toByteStreamK(reliableDownloadOptions, maxQueueSize) mapF
       handlers.recoverNotFound[F, Stream[F, Byte]]
 
-  def mk[F[_]: ConcurrentEffect: ContextShift](containerURL: ContainerURL, maxQueueSize: MaxQueueSize)
-      : GetService[F] =
+  def mk[F[_]: ConcurrentEffect: ContextShift](containerURL: ContainerURL, maxQueueSize: MaxQueueSize): GetService[F] =
     AzureGetService(
       containerURL,
       DownloadArgs(_, BlobRange.DEFAULT, BlobAccessConditions.NONE, false, Context.NONE),

--- a/azure/src/main/scala/quasar/blobstore/azure/AzurePutService.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/AzurePutService.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014–2019 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import scala._
+
+import quasar.blobstore.azure.requests.UploadRequestArgs
+import quasar.blobstore.services.PutService
+
+import com.microsoft.azure.storage.blob._
+
+import java.nio.ByteBuffer
+
+import cats.effect.{ContextShift, ConcurrentEffect}
+import cats.data.Kleisli
+
+object AzurePutService {
+  private val ChunkLength = 10 * 1024 * 1024
+  private val Buffers = 2
+
+  def apply[F[_]: ContextShift: ConcurrentEffect](
+    containerURL: ContainerURL,
+    blockSize: Int,
+    numBuffers: Int,
+    transferOptions: TransferManagerUploadToBlockBlobOptions)
+      : PutService[F] =
+    for {
+      (blobPath, st) <- Kleisli.ask
+      url <- Kleisli.liftF(converters.mkBlobUrl(containerURL)(blobPath))
+      blockURL = url.toBlockBlobURL
+      flowable = rx.streamToFlowable[F, ByteBuffer](st.chunks.map(_.toByteBuffer))
+      args = UploadRequestArgs(flowable, blockURL, blockSize, numBuffers, transferOptions)
+      upload <- Kleisli.liftF(requests.uploadRequest(args))
+    } yield upload.statusCode
+
+  def mk[F[_]: ConcurrentEffect: ContextShift](containerURL: ContainerURL)
+      : PutService[F] =
+    AzurePutService(
+      containerURL,
+      ChunkLength,
+      Buffers,
+      TransferManagerUploadToBlockBlobOptions.DEFAULT)
+}

--- a/azure/src/main/scala/quasar/blobstore/azure/requests.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/requests.scala
@@ -16,9 +16,12 @@
 
 package quasar.blobstore.azure
 
+import scala.Predef._
+
+import scala.{Int, Array, Boolean, Option}
+
 import java.lang.SuppressWarnings
-import scala.{Array, Boolean, Option}
-import scala.Predef.String
+import java.nio.ByteBuffer
 
 import cats.data.Kleisli
 import cats.effect.{Async, ContextShift, Sync}
@@ -26,44 +29,93 @@ import cats.syntax.flatMap._
 import com.microsoft.azure.storage.blob._
 import com.microsoft.azure.storage.blob.models._
 import com.microsoft.rest.v2.Context
+import io.reactivex.Flowable
 
 object requests {
 
-  final case class ListBlobHierarchyArgs(containerURL: ContainerURL, marker: Option[String], delimiter: String, options: ListBlobsOptions, context: Context)
+  final case class ListBlobHierarchyArgs(
+    containerURL: ContainerURL,
+    marker: Option[String],
+    delimiter: String,
+    options: ListBlobsOptions,
+    context: Context)
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  def listRequest[F[_]: Async: ContextShift](args: ListBlobHierarchyArgs): F[ContainerListBlobHierarchySegmentResponse] =
-    Sync[F].delay(args.containerURL.listBlobsHierarchySegment(args.marker.orNull, args.delimiter, args.options, args.context)) >>=
+  def listRequest[F[_]: Async: ContextShift](
+    args: ListBlobHierarchyArgs): F[ContainerListBlobHierarchySegmentResponse] =
+    Sync[F].delay(
+      args.containerURL.listBlobsHierarchySegment(
+        args.marker.orNull,
+        args.delimiter,
+        args.options,
+        args.context)) >>=
       rx.singleToAsync[F, ContainerListBlobHierarchySegmentResponse]
 
-  def listRequestK[F[_]: Async: ContextShift]: Kleisli[F, ListBlobHierarchyArgs, ContainerListBlobHierarchySegmentResponse] =
+  def listRequestK[F[_]: Async: ContextShift]
+      : Kleisli[F, ListBlobHierarchyArgs, ContainerListBlobHierarchySegmentResponse] =
     Kleisli(listRequest[F])
 
-  final case class BlobPropsArgs(blobURL: BlobURL, blobAccessConditions: BlobAccessConditions, context: Context)
+  final case class BlobPropsArgs(
+    blobURL: BlobURL,
+    blobAccessConditions: BlobAccessConditions,
+    context: Context)
 
-  def blobPropsRequest[F[_]: Async: ContextShift](args: BlobPropsArgs): F[BlobGetPropertiesResponse] =
+  def blobPropsRequest[F[_]: Async: ContextShift](
+    args: BlobPropsArgs): F[BlobGetPropertiesResponse] =
     Sync[F].delay(args.blobURL.getProperties(args.blobAccessConditions, args.context)) >>=
       rx.singleToAsync[F, BlobGetPropertiesResponse]
 
-  def blobPropsRequestK[F[_]: Async: ContextShift]: Kleisli[F, BlobPropsArgs, BlobGetPropertiesResponse] =
+  def blobPropsRequestK[F[_]: Async: ContextShift]
+      : Kleisli[F, BlobPropsArgs, BlobGetPropertiesResponse] =
     Kleisli(blobPropsRequest[F])
 
-  final case class DownloadArgs(blobURL: BlobURL, blobRange: BlobRange, blobAccessConditions: BlobAccessConditions, rangeGetContentMD5: Boolean, context: Context)
+  final case class DownloadArgs(
+    blobURL: BlobURL,
+    blobRange: BlobRange,
+    blobAccessConditions: BlobAccessConditions,
+    rangeGetContentMD5: Boolean,
+    context: Context)
 
   def downloadRequest[F[_]: Async: ContextShift](args: DownloadArgs): F[DownloadResponse] =
-    Sync[F].delay(args.blobURL.download(args.blobRange, args.blobAccessConditions, args.rangeGetContentMD5, args.context)) >>=
+    Sync[F].delay(
+      args.blobURL.download(
+        args.blobRange,
+        args.blobAccessConditions,
+        args.rangeGetContentMD5,
+        args.context)) >>=
       rx.singleToAsync[F, DownloadResponse]
 
   def downloadRequestK[F[_]: Async: ContextShift]: Kleisli[F, DownloadArgs, DownloadResponse] =
     Kleisli(downloadRequest[F])
 
-  final case class ContainerPropsArgs(containerURL: ContainerURL, leaseAccessConditions: LeaseAccessConditions, context: Context)
+  final case class ContainerPropsArgs(
+    containerURL: ContainerURL,
+    leaseAccessConditions: LeaseAccessConditions,
+    context: Context)
 
-  def containerPropsRequest[F[_]: Async: ContextShift](args: ContainerPropsArgs): F[ContainerGetPropertiesResponse] =
+  def containerPropsRequest[F[_]: Async: ContextShift](
+    args: ContainerPropsArgs): F[ContainerGetPropertiesResponse] =
     Sync[F].delay(args.containerURL.getProperties(args.leaseAccessConditions, args.context)) >>=
       rx.singleToAsync[F, ContainerGetPropertiesResponse]
 
-  def containerPropsRequestK[F[_]: Async: ContextShift]: Kleisli[F, ContainerPropsArgs, ContainerGetPropertiesResponse] =
+  def containerPropsRequestK[F[_]: Async: ContextShift]
+      : Kleisli[F, ContainerPropsArgs, ContainerGetPropertiesResponse] =
     Kleisli(containerPropsRequest[F])
 
+  final case class UploadRequestArgs(
+    source: Flowable[ByteBuffer],
+    url: BlockBlobURL,
+    blockSize: Int,
+    numBuffers: Int,
+    options: TransferManagerUploadToBlockBlobOptions)
+
+  def uploadRequest[F[_]: Async: ContextShift](args: UploadRequestArgs)
+      : F[BlockBlobCommitBlockListResponse] =
+    Async[F].delay(TransferManager.uploadFromNonReplayableFlowable(
+      args.source, args.url, args.blockSize, args.numBuffers, args.options)) >>=
+        rx.singleToAsync[F, BlockBlobCommitBlockListResponse]
+
+  def uploadRequestK[F[_]: Async: ContextShift]
+      : Kleisli[F, UploadRequestArgs, BlockBlobCommitBlockListResponse] =
+    Kleisli(uploadRequest[F])
 }

--- a/azure/src/main/scala/quasar/blobstore/azure/rx.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/rx.scala
@@ -27,6 +27,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import fs2.{RaiseThrowable, Stream}
 import fs2.concurrent.Queue
+import fs2.interop.reactivestreams._
 import io.reactivex.{Flowable, Single, SingleObserver}
 import io.reactivex.observers.DisposableSingleObserver
 import io.reactivex.subscribers.DefaultSubscriber
@@ -68,6 +69,9 @@ object rx {
       if (callback != null) callback(Left(t))
       else ()
   }
+
+  def streamToFlowable[F[_]: ConcurrentEffect, A](s: Stream[F, A]): Flowable[A] =
+    Flowable.fromPublisher(s.toUnicastPublisher)
 
   def flowableToStream[F[_]: ConcurrentEffect: RaiseThrowable, A](
       f: Flowable[A],

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ lazy val core = project
     name := "async-blobstore-core",
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %% "monocle-core" % "1.6.0",
-      "co.fs2" %% "fs2-core" % "1.0.5"))
+      "co.fs2" %% "fs2-core" % "1.0.5",
+      "co.fs2" %% "fs2-reactive-streams" % "1.0.5"))
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val azure = project

--- a/core/src/main/scala/quasar/blobstore/services.scala
+++ b/core/src/main/scala/quasar/blobstore/services.scala
@@ -18,7 +18,7 @@ package quasar.blobstore
 
 import quasar.blobstore.paths.{BlobPath, BlobstorePath, PrefixPath}
 
-import scala.{Byte, Option, Unit, Int}
+import scala.{Byte, Option, Int}
 
 import cats.data.Kleisli
 import fs2.Stream

--- a/core/src/main/scala/quasar/blobstore/services.scala
+++ b/core/src/main/scala/quasar/blobstore/services.scala
@@ -18,7 +18,7 @@ package quasar.blobstore
 
 import quasar.blobstore.paths.{BlobPath, BlobstorePath, PrefixPath}
 
-import scala.{Byte, Option}
+import scala.{Byte, Option, Unit, Int}
 
 import cats.data.Kleisli
 import fs2.Stream
@@ -32,5 +32,7 @@ object services {
   type PropsService[F[_], P] = Kleisli[F, BlobPath, Option[P]]
 
   type ListService[F[_]] = Kleisli[F, PrefixPath, Option[Stream[F, BlobstorePath]]]
+
+  type PutService[F[_]] = Kleisli[F, (BlobPath, Stream[F, Byte]), Int]
 
 }


### PR DESCRIPTION
This adds `PutService` using `TransferManager` and `fs2-reactive-streams` to convert `fs2`'s streams into a `Flowable`.

This is the first part of the Azure destination.

[ch9646]