### PR TITLE
Add Azure Active Directory authentication support

### DIFF
--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -48,7 +48,7 @@ object Azure {
             .tenantId(tenantId.value)
             .clientSecret(clientSecret.value)
             .build()
-            .getToken((new TokenRequestContext()).setScopes(List("https://storage.azure.com/user_impersonation").asJava)))
+            .getToken((new TokenRequestContext()).setScopes(List("https://storage.azure.com/.default").asJava)))
           .compile
           .lastOrError
           .map(tk => new TokenCredentials(tk.getToken))

--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -70,6 +70,7 @@ object Azure extends Logging {
       // In 10.2.0 the standard `new PipelineOptions` could be used, but in 10.3.0
       // this results in messages being logged to console in eg quasar's repl
       // (despite having no console logger configured).
+      // Still not having a full understanding of how this logging is supposed to work
       // exactly (e.g. `withLogger`) but adding `LoggingOptions` with
       // `disableDefaultLogging = true` seems to be fixing it.
       // As an aside, in case we need to look at this in the future,

--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -19,6 +19,7 @@ package quasar.blobstore.azure
 import java.net.URL
 
 import scala._
+import collection.JavaConverters._
 
 import cats.implicits._
 import cats.effect.ConcurrentEffect
@@ -47,7 +48,7 @@ object Azure {
             .tenantId(tenantId.value)
             .clientSecret(clientSecret.value)
             .build()
-            .getToken(new TokenRequestContext()))
+            .getToken((new TokenRequestContext()).setScopes(List("https://storage.azure.com/user_impersonation").asJava)))
           .compile
           .lastOrError
           .map(tk => new TokenCredentials(tk.getToken))

--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -19,7 +19,6 @@ package quasar.blobstore.azure
 import java.net.URL
 
 import scala._
-import scala.Predef._
 import collection.JavaConverters._
 
 import cats.implicits._
@@ -44,14 +43,12 @@ object Azure {
 
       case Some(AzureCredentials.ActiveDirectory(clientId, tenantId, clientSecret)) =>
         rx.publisherToStream[F, AccessToken](
-            (new ClientSecretCredentialBuilder())
-              .clientId(clientId.value)
-              .tenantId(tenantId.value)
-              .clientSecret(clientSecret.value)
-              .build()
-              .getToken((new TokenRequestContext()).setScopes(
-                List("https://storage.azure.com/.default").asJava)))
-          .evalTap(tk => ConcurrentEffect[F].delay(println(tk.getExpiresAt())))
+          (new ClientSecretCredentialBuilder())
+            .clientId(clientId.value)
+            .tenantId(tenantId.value)
+            .clientSecret(clientSecret.value)
+            .build()
+            .getToken((new TokenRequestContext()).setScopes(List("https://storage.azure.com/.default").asJava)))
           .compile
           .lastOrError
           .map(tk => new TokenCredentials(tk.getToken))

--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -19,6 +19,7 @@ package quasar.blobstore.azure
 import java.net.URL
 
 import scala._
+import scala.Predef._
 import collection.JavaConverters._
 
 import cats.implicits._
@@ -43,12 +44,14 @@ object Azure {
 
       case Some(AzureCredentials.ActiveDirectory(clientId, tenantId, clientSecret)) =>
         rx.publisherToStream[F, AccessToken](
-          (new ClientSecretCredentialBuilder())
-            .clientId(clientId.value)
-            .tenantId(tenantId.value)
-            .clientSecret(clientSecret.value)
-            .build()
-            .getToken((new TokenRequestContext()).setScopes(List("https://storage.azure.com/.default").asJava)))
+            (new ClientSecretCredentialBuilder())
+              .clientId(clientId.value)
+              .tenantId(tenantId.value)
+              .clientSecret(clientSecret.value)
+              .build()
+              .getToken((new TokenRequestContext()).setScopes(
+                List("https://storage.azure.com/.default").asJava)))
+          .evalTap(tk => ConcurrentEffect[F].delay(println(tk.getExpiresAt())))
           .compile
           .lastOrError
           .map(tk => new TokenCredentials(tk.getToken))

--- a/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/Azure.scala
@@ -18,42 +18,62 @@ package quasar.blobstore.azure
 
 import java.net.URL
 
-import scala.{None, Option, Some, StringContext}
+import scala._
 
-import cats.effect.Sync
-import cats.syntax.functor._
+import cats.implicits._
+import cats.effect.ConcurrentEffect
+
 import com.microsoft.azure.storage.blob._
+import com.azure.identity.ClientSecretCredentialBuilder
+import com.azure.core.credential.{AccessToken, TokenRequestContext}
 
 object Azure {
 
   def mkStdStorageUrl(name: AccountName): StorageUrl =
     StorageUrl(s"https://${name.value}.blob.core.windows.net/")
 
-  def mkCredentials(cred: Option[AzureCredentials]): ICredentials =
+  def mkCredentials[F[_]: ConcurrentEffect](cred: Option[AzureCredentials]): F[ICredentials] =
     cred match {
-      case None => new AnonymousCredentials
-      case Some(c) => new SharedKeyCredentials(c.accountName.value, c.accountKey.value)
+      case None =>
+        (new AnonymousCredentials(): ICredentials).pure[F]
+
+      case Some(AzureCredentials.SharedKey(accountName, accountKey)) =>
+        (new SharedKeyCredentials(accountName.value, accountKey.value): ICredentials).pure[F]
+
+      case Some(AzureCredentials.ActiveDirectory(clientId, tenantId, clientSecret)) =>
+        rx.publisherToStream[F, AccessToken](
+          (new ClientSecretCredentialBuilder())
+            .clientId(clientId.value)
+            .tenantId(tenantId.value)
+            .clientSecret(clientSecret.value)
+            .build()
+            .getToken(new TokenRequestContext()))
+          .compile
+          .lastOrError
+          .map(tk => new TokenCredentials(tk.getToken))
     }
 
-  def mkContainerUrl[F[_]](cfg: Config)(implicit F: Sync[F]): F[ContainerURL] =
-    F.catchNonFatal(new URL(cfg.storageUrl.value)) map { url =>
-      val serviceUrl = new ServiceURL(
-        url,
-        StorageURL.createPipeline(
-          mkCredentials(cfg.credentials),
-          // Azure SDK changed its logging behavior in 10.3.0 (compared to 10.2.0).
-          // In 10.2.0 the standard `new PipelineOptions` could be used, but in 10.3.0
-          // this results in messages being logged to console in eg quasar's repl
-          // (despite having no console logger configured).
-          // Still not having a full understanding of how this logging is supposed to work
-          // exactly (e.g. `withLogger`) but adding `LoggingOptions` with
-          // `disableDefaultLogging = true` seems to be fixing it.
-          // As an aside, in case we need to look at this in the future,
-          // Azure SDK has 2 loggers for some reason:
-          // - `com.microsoft.azure.storage.blob.LoggingFactory`
-          // - `Azure Storage Java SDK`
-          new PipelineOptions().withLoggingOptions(
-            new LoggingOptions(3000, true))))
-      serviceUrl.createContainerURL(cfg.containerName.value)
+  def mkContainerUrl[F[_]](cfg: Config)(implicit F: ConcurrentEffect[F]): F[ContainerURL] =
+    F.catchNonFatal(new URL(cfg.storageUrl.value)) flatMap { url =>
+      // Azure SDK changed its logging behavior in 10.3.0 (compared to 10.2.0).
+      // In 10.2.0 the standard `new PipelineOptions` could be used, but in 10.3.0
+      // this results in messages being logged to console in eg quasar's repl
+      // (despite having no console logger configured).
+      // exactly (e.g. `withLogger`) but adding `LoggingOptions` with
+      // `disableDefaultLogging = true` seems to be fixing it.
+      // As an aside, in case we need to look at this in the future,
+      // Azure SDK has 2 loggers for some reason:
+      // - `com.microsoft.azure.storage.blob.LoggingFactory`
+      // - `Azure Storage Java SDK`
+
+      mkCredentials(cfg.credentials)
+        .map(creds =>
+          new ServiceURL(
+            url,
+            StorageURL.createPipeline(
+              creds,
+              new PipelineOptions().withLoggingOptions(
+                new LoggingOptions(3000, true)))))
+        .map(_.createContainerURL(cfg.containerName.value))
     }
 }

--- a/azure/src/main/scala/quasar/blobstore/azure/config.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/config.scala
@@ -16,7 +16,7 @@
 
 package quasar.blobstore.azure
 
-import scala.{Int, Option}
+import scala.{Int, Option, Product, Serializable}
 import scala.Predef.String
 
 import eu.timepit.refined.api.Refined
@@ -29,7 +29,22 @@ final case class StorageUrl(value: String)
 final case class AccountName(value: String)
 final case class AccountKey(value: String)
 
-final case class AzureCredentials(accountName: AccountName, accountKey: AccountKey)
+final case class ClientId(value: String)
+final case class ClientSecret(value: String)
+final case class TenantId(value: String)
+
+sealed trait AzureCredentials extends Product with Serializable
+
+object AzureCredentials {
+  final case class SharedKey(
+    accountName: AccountName,
+    accountKey: AccountKey) extends AzureCredentials
+
+  final case class ActiveDirectory(
+    clientId: ClientId,
+    tenantId: TenantId,
+    clientSecret: ClientSecret) extends AzureCredentials
+}
 
 final case class MaxQueueSize(value: Int Refined Positive)
 

--- a/azure/src/main/scala/quasar/blobstore/azure/config.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/config.scala
@@ -56,7 +56,7 @@ object MaxQueueSize {
   def default: MaxQueueSize = MaxQueueSize(10)
 }
 
-final case class Expires[+A](value: A, expiresAt: OffsetDateTime)
+final case class Expires[A](value: A, expiresAt: OffsetDateTime)
 
 object Expires {
   def never[A](value: A): Expires[A] =

--- a/azure/src/main/scala/quasar/blobstore/azure/config.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/config.scala
@@ -19,6 +19,10 @@ package quasar.blobstore.azure
 import scala.{Int, Option, Product, Serializable}
 import scala.Predef.String
 
+import java.time.OffsetDateTime
+
+import cats._
+
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
@@ -50,6 +54,18 @@ final case class MaxQueueSize(value: Int Refined Positive)
 
 object MaxQueueSize {
   def default: MaxQueueSize = MaxQueueSize(10)
+}
+
+final case class Expires[+A](value: A, expiresAt: OffsetDateTime)
+
+object Expires {
+  def never[A](value: A): Expires[A] =
+    Expires(value, OffsetDateTime.MAX)
+
+  implicit def expiresFunctor: Functor[Expires] = new Functor[Expires] {
+    def map[A, B](fa: Expires[A])(f: A => B): Expires[B] =
+      Expires(f(fa.value), fa.expiresAt)
+  }
 }
 
 trait Config {

--- a/azure/src/main/scala/quasar/blobstore/azure/rx.scala
+++ b/azure/src/main/scala/quasar/blobstore/azure/rx.scala
@@ -31,6 +31,7 @@ import fs2.interop.reactivestreams._
 import io.reactivex.{Flowable, Single, SingleObserver}
 import io.reactivex.observers.DisposableSingleObserver
 import io.reactivex.subscribers.DefaultSubscriber
+import org.reactivestreams.Publisher
 
 object rx {
   final class AsyncSubscriber[F[_]: Sync, A](cb: Either[Throwable, Option[F[A]]] => Unit) extends DefaultSubscriber[A] {
@@ -77,6 +78,10 @@ object rx {
       f: Flowable[A],
       maxQueueSize: Int Refined Positive): Stream[F, A] =
     handlerToStream(flowableToHandler(f), maxQueueSize)
+
+  def publisherToStream[F[_]: ConcurrentEffect, A](
+    p: Publisher[A]): Stream[F, A] =
+    fromPublisher(p)
 
   def flowableToHandler[F[_]: Sync, A](flowable: Flowable[A]): (Either[Throwable, Option[F[A]]] => Unit) => F[Unit] = { cb =>
     val sub = new AsyncSubscriber[F, A](cb)

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val azure = project
   .settings(
     name := "async-blobstore-azure",
     libraryDependencies ++= Seq(
+      "org.slf4s" %% "slf4s-api" % "1.7.25",
       "com.microsoft.azure" % "azure-storage-blob" % "10.5.0",
       "com.azure" % "azure-identity" % "1.0.0",
       "eu.timepit" %% "refined" % "0.9.9",

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val azure = project
     name := "async-blobstore-azure",
     libraryDependencies ++= Seq(
       "com.microsoft.azure" % "azure-storage-blob" % "10.5.0",
+      "com.azure" % "azure-identity" % "1.0.0",
       "eu.timepit" %% "refined" % "0.9.9",
       // netty-all isn't strictly necessary but takes advantage of native libs.
       // Azure doesn't pull in libs like netty-transport-native-kqueue,


### PR DESCRIPTION
[ch10044]

This PR adds support for Azure Active Directory authentication. This is necessary in the Avalanche destination. Will file PRs depending on this for `quasar-datasource-azure` and `quasar-destination-azure`.