### PR TITLE
Add netty-all as explicit dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ scmInfo in ThisBuild := Some(ScmInfo(
 val AwsSdkVersion = "2.9.1"
 val Fs2Version = "2.2.1"
 val MonixVersion = "3.0.0"
+// Make sure this is the same for different sub projectss
+val NettyVersion = "4.1.44.Final"
 
 // Include to also publish a project's tests
 lazy val publishTestsSettings = Seq(
@@ -44,6 +46,7 @@ lazy val s3 = project
     name := "async-blobstore-s3",
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % Fs2Version,
+      "io.netty" % "netty-all" % NettyVersion,
       "io.monix" %% "monix-catnap" % MonixVersion,
       "software.amazon.awssdk" % "netty-nio-client" % AwsSdkVersion,
       "software.amazon.awssdk" % "s3" % AwsSdkVersion))
@@ -57,6 +60,7 @@ lazy val azure = project
     name := "async-blobstore-azure",
     libraryDependencies ++= Seq(
       "ch.timo-schmid" %% "slf4s-api" % "1.7.26",
+      "io.netty" % "netty-all" % NettyVersion,
       "com.microsoft.azure" % "azure-storage-blob" % "10.5.0",
       "com.azure" % "azure-identity" % "1.0.0",
       "eu.timepit" %% "refined" % "0.9.9",


### PR DESCRIPTION
[ch10860]

... adding it to both s3 and azure to make sure the versions stay in sync.
Also including netty-all to make sure that all netty artifacts have the
same version further downstream